### PR TITLE
feat: use nanoevents instead of events

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "typescript": "^4.0.3"
   },
   "dependencies": {
+    "nanoevents": "^6.0.0",
     "oneline": "^1.0.3",
     "serialize-error": "^2.1.0",
     "tiny-uid": "^1.1.1",


### PR DESCRIPTION
`events` is a Node.js module with require builders to polypill it. Switch to `nanoevents` to clear dependencies tree and save some bits.